### PR TITLE
Fix the install-cmd skipping

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,5 +42,5 @@ runs:
       shell: bash
 
     - run: ${{ inputs.install-cmd }}
-      if: ${{ inputs.install-cmd != '' && steps.cache-venv.outputs.cache-hit != 'true' }}
+      if: inputs.install-cmd != '' && steps.cache-venv.outputs.cache-hit != 'true'
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -42,5 +42,5 @@ runs:
       shell: bash
 
     - run: ${{ inputs.install-cmd }}
-      if: "${{ inputs.install-cmd }} != '' && ${{ steps.cache-venv.outputs.cache-hit }} != 'true'"
+      if: ${{ inputs.install-cmd != '' && steps.cache-venv.outputs.cache-hit != 'true' }}
       shell: bash


### PR DESCRIPTION
I broke this when handling scenario of no install-cmd, this fixes it.

Run: https://github.com/getsentry/action-setup-venv/actions/runs/3914395944/jobs/6691401481