### PR TITLE
Bumping deps to node20 compatible versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ when the cache is available.
 ### Usage
 
 ```yaml
-    - uses: getsentry/action-setup-venv@v1.0.4
+    - uses: getsentry/action-setup-venv@v2.0.0
       id: venv
       with:
         python-version: 3.10.7

--- a/action.yml
+++ b/action.yml
@@ -20,12 +20,12 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984  # v4.3.0
+    - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c  # v5.0.0
       id: setup-python
       with:
         python-version: ${{ inputs.python-version }}
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2  # v4.0.0
       id: cache-venv
       with:
         path: ${{ inputs.venv-dir }}


### PR DESCRIPTION
Updating the action to use node20 compatible workflows as node16 is now deprecated.