### PR TITLE
disable noisy error matcher

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
+    - run: echo '::remove-matcher owner=python::'
+      shell: bash
+
     - uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2  # v4.0.0
       id: cache-venv
       with:


### PR DESCRIPTION
this is added by actions/setup-python and the annotations it creates make it difficult to read code diffs (and sometimes flag unrelated logging messages)