### PR TITLE
fix: working-directory for .python-version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
       id: setup-python
       with:
         python-version: ${{ inputs.python-version }}
-        python-version-file: ${{ hashFiles('.python-version') == '' && '' || '.python-version' }}
+        python-version-file: ${{ hashFiles(inputs.working-directory + '/.python-version') == '' && '' || inputs.working-directory + '/.python-version' }}
 
     - run: echo '::remove-matcher owner=python::'
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
       id: setup-python
       with:
         python-version: ${{ inputs.python-version }}
-        python-version-file: ${{ hashFiles(inputs.working-directory + '/.python-version') == '' && '' || inputs.working-directory + '/.python-version' }}
+        python-version-file: ${{ hashFiles(format('{0}/.python-version', inputs.working-directory)) == '' && '' || format('{0}/.python-version', inputs.working-directory) }}
 
     - run: echo '::remove-matcher owner=python::'
       shell: bash


### PR DESCRIPTION
followup to https://github.com/getsentry/action-setup-venv/pull/24 where i noticed .python-version was missing working-directory support